### PR TITLE
Dependency fix

### DIFF
--- a/backbone-rails.gemspec
+++ b/backbone-rails.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.description = "Quickly setup backbone.js for use with rails 3.1. Generators are provided to quickly get started."
   s.files = Dir["lib/**/*"] + Dir["vendor/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
   
-  s.add_dependency('rails', '~> 3.1')
+  s.add_dependency('rails', '~> 3.1.0.rc4')
   s.add_dependency('coffee-script', '~> 2.2')
   s.add_dependency('ejs', '~> 1.0.0')
   


### PR DESCRIPTION
Dropped the dependency for rails in the gemspec file to 3.1.0.rc4 as 3.1 is not out yet.

I could not upgrade to the latest version of the gem without this change.
