### PR TITLE
Generated models missing url property when used outside a collection

### DIFF
--- a/lib/generators/backbone/model/templates/model.coffee
+++ b/lib/generators/backbone/model/templates/model.coffee
@@ -1,5 +1,6 @@
 class <%= model_namespace %> extends Backbone.Model
   paramRoot: '<%= singular_table_name %>'
+  urlRoot: '<%= route_url %>'
 
   defaults:
 <% attributes.each do |attribute| -%>


### PR DESCRIPTION
Model instances used outside a collection can't call `collection.url` to get their URL, so they use the `urlRoot` property. The generators don't currently define this, so this patch adds that property. It's set to the same `route_url` as the `collection.url` property.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/codebrew/backbone-rails/21)
<!-- Reviewable:end -->
