### PR TITLE
Values with spaces render incorrectly because edit and new templates are missing quotes

### DIFF
--- a/lib/generators/backbone/scaffold/templates/templates/edit.jst
+++ b/lib/generators/backbone/scaffold/templates/templates/edit.jst
@@ -4,7 +4,7 @@
 <% attributes.each do |attribute| -%>
   <div class="field">
     <label for="<%= attribute.name %>"> <%= attribute.name %>:</label>
-    <input type="text" name="<%= attribute.name %>" id="<%= attribute.name %>" value=<%%= <%= attribute.name %> %> >
+    <input type="text" name="<%= attribute.name %>" id="<%= attribute.name %>" value="<%%= <%= attribute.name %> %>" >
   </div>
 
 <% end -%>

--- a/lib/generators/backbone/scaffold/templates/templates/new.jst
+++ b/lib/generators/backbone/scaffold/templates/templates/new.jst
@@ -4,7 +4,7 @@
 <% attributes.each do |attribute| -%>
   <div class="field">
     <label for="<%= attribute.name %>"> <%= attribute.name %>:</label>
-    <input type="text" name="<%= attribute.name %>" id="<%= attribute.name %>" value=<%%= <%= attribute.name %> %> >
+    <input type="text" name="<%= attribute.name %>" id="<%= attribute.name %>" value="<%%= <%= attribute.name %> %>" >
   </div>
 
 <% end -%>


### PR DESCRIPTION
fixed lack of quotes in edit.jst and new.jst scaffold templates - values with spaces were causing problems
