### PR TITLE
Fixed index view to work for model with two words

### DIFF
--- a/lib/generators/backbone/resource_helpers.rb
+++ b/lib/generators/backbone/resource_helpers.rb
@@ -1,43 +1,47 @@
 module Backbone
   module Generators
     module ResourceHelpers
-      
+
       def backbone_path
         "app/assets/javascripts/backbone"
       end
-      
+
       def model_namespace
         [js_app_name, "Models", class_name].join(".")
       end
-      
+
       def singular_model_name
         uncapitalize singular_name.camelize
       end
-      
+
       def plural_model_name
         uncapitalize(plural_name.camelize)
       end
-      
+
+      def underscored_plural_model_name
+        plural_name.tableize
+      end
+
       def collection_namespace
         [js_app_name, "Collections", plural_name.camelize].join(".")
       end
-      
+
       def view_namespace
         [js_app_name, "Views", plural_name.camelize].join(".")
       end
-      
+
       def router_namespace
         [js_app_name, "Routers", plural_name.camelize].join(".")
       end
-      
+
       def jst(action)
         "backbone/templates/#{plural_name}/#{action}"
       end
-      
+
       def js_app_name
         application_name.camelize
       end
-      
+
       def application_name
         if defined?(Rails) && Rails.application
           Rails.application.class.name.split('::').first
@@ -45,11 +49,11 @@ module Backbone
           "application"
         end
       end
-      
+
       def uncapitalize(str)
           str[0, 1].downcase + str[1..-1]
       end
-      
+
     end
   end
 end

--- a/lib/generators/backbone/scaffold/templates/router.coffee
+++ b/lib/generators/backbone/scaffold/templates/router.coffee
@@ -1,7 +1,7 @@
 class <%= router_namespace %>Router extends Backbone.Router
   initialize: (options) ->
-    @<%= plural_model_name %> = new <%= collection_namespace %>Collection()
-    @<%= plural_model_name %>.reset options.<%= plural_model_name %>
+    @<%= underscored_plural_model_name %> = new <%= collection_namespace %>Collection()
+    @<%= underscored_plural_model_name %>.reset options.<%= underscored_plural_model_name %>
 
   routes:
     "/new": "new<%= class_name %>"
@@ -11,22 +11,21 @@ class <%= router_namespace %>Router extends Backbone.Router
     ".*": "index"
 
   new<%= class_name %>: ->
-    @view = new <%= "#{view_namespace}.NewView(collection: @#{plural_name})" %>
+    @view = new <%= "#{view_namespace}.NewView(collection: @#{underscored_plural_model_name})" %>
     $("#<%= plural_name %>").html(@view.render().el)
 
   index: ->
-    @view = new <%= "#{view_namespace}.IndexView(#{plural_name}: @#{plural_name})" %>
+    @view = new <%= "#{view_namespace}.IndexView(#{plural_name}: @#{underscored_plural_model_name})" %>
     $("#<%= plural_name %>").html(@view.render().el)
 
   show: (id) ->
-    <%= singular_name %> = @<%= plural_name %>.get(id)
-    
+    <%= singular_name %> = @<%= underscored_plural_model_name %>.get(id)
+
     @view = new <%= "#{view_namespace}.ShowView(model: #{singular_name})" %>
     $("#<%= plural_name %>").html(@view.render().el)
-    
+
   edit: (id) ->
-    <%= singular_name %> = @<%= plural_name %>.get(id)
+    <%= singular_name %> = @<%= underscored_plural_model_name %>.get(id)
 
     @view = new <%= "#{view_namespace}.EditView(model: #{singular_name})" %>
     $("#<%= plural_name %>").html(@view.render().el)
-  

--- a/lib/generators/backbone/scaffold/templates/views/index_view.coffee
+++ b/lib/generators/backbone/scaffold/templates/views/index_view.coffee
@@ -2,21 +2,21 @@
 
 class <%= view_namespace %>.IndexView extends Backbone.View
   template: JST["<%= jst 'index' %>"]
-    
+
   initialize: () ->
     _.bindAll(this, 'addOne', 'addAll', 'render');
-    
-    @options.<%= plural_model_name %>.bind('reset', this.addAll);
-   
+
+    @options.<%= underscored_plural_model_name %>.bind('reset', this.addAll);
+
   addAll: () ->
-    @options.<%= plural_model_name %>.each(this.addOne)
-  
+    @options.<%= underscored_plural_model_name %>.each(this.addOne)
+
   addOne: (<%= singular_model_name %>) ->
     view = new <%= view_namespace %>.<%= singular_name.camelize %>View({model : <%= singular_model_name %>})
     this.$("tbody").append(view.render().el)
-       
+
   render: ->
-    $(this.el).html(this.template(<%= plural_model_name %>: this.options.<%= plural_model_name %>.toJSON() ))
+    $(this.el).html(this.template(<%= plural_model_name %>: this.options.<%= underscored_plural_model_name %>.toJSON() ))
     @addAll()
-    
+
     return this

--- a/test/generators/scaffold_generator_test.rb
+++ b/test/generators/scaffold_generator_test.rb
@@ -6,122 +6,122 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
   include GeneratorsTestHelper
   tests Backbone::Generators::ScaffoldGenerator
   arguments %w(Post title:string content:string)
-  
+
   test "generate router scaffolding" do
     run_generator
-    
+
     assert_file "#{backbone_path}/routers/posts_router.js.coffee" do |router|
       assert_match /class Dummy.Routers.PostsRouter extends Backbone.Router/, router
       assert_match /newPost: ->/, router
       assert_match /@posts.reset options.posts/, router
-      
+
       %w(NewView IndexView ShowView EditView).each do |view|
         assert_match /new Dummy.Views.Posts.#{view}/, router
       end
     end
   end
-  
+
   test "generate router scaffolding for model with two words" do
     run_generator %w(BlogPost title:string content:string)
-    
+
     assert_file "#{backbone_path}/routers/blog_posts_router.js.coffee" do |router|
       assert_match /class Dummy.Routers.BlogPostsRouter extends Backbone.Router/, router
       assert_match /newBlogPost: ->/, router
-      assert_match /@blogPosts.reset options.blogPosts/, router
-      
+      assert_match /@blog_posts.reset options.blog_posts/, router
+
       %w(NewView IndexView ShowView EditView).each do |view|
         assert_match /new Dummy.Views.BlogPosts.#{view}/, router
       end
     end
   end
-  
+
   test "generate view files" do
     run_generator
-    
+
     assert_file "#{backbone_path}/views/posts/index_view.js.coffee" do |view|
       assert_match /#{Regexp.escape('JST["backbone/templates/posts/index"]')}/, view
       assert_match /#{Regexp.escape('this.template(posts: this.options.posts.toJSON() ))')}/, view
       assert_match /#{Regexp.escape("new Dummy.Views.Posts.PostView({model : post})")}/, view
     end
-    
+
     assert_file "#{backbone_path}/views/posts/show_view.js.coffee" do |view|
       assert_match /class Dummy.Views.Posts.ShowView extends Backbone.View/, view
       assert_match /#{Regexp.escape('this.template(this.options.model.toJSON() )')}/, view
       assert_match /#{Regexp.escape('template: JST["backbone/templates/posts/show"]')}/, view
     end
-    
+
     assert_file "#{backbone_path}/views/posts/new_view.js.coffee" do |view|
       assert_match /class Dummy.Views.Posts.NewView extends Backbone.View/, view
       assert_match /#{Regexp.escape('this.template(@options.model.toJSON() )')}/, view
       assert_match /#{Regexp.escape('JST["backbone/templates/posts/new"]')}/, view
       assert_match /#{Regexp.escape('"submit #new-post": "save"')}/, view
     end
-    
+
     assert_file "#{backbone_path}/views/posts/edit_view.js.coffee" do |view|
       assert_match /class Dummy.Views.Posts.EditView extends Backbone.View/, view
       assert_match /#{Regexp.escape('JST["backbone/templates/posts/edit"]')}/, view
       assert_match /#{Regexp.escape('"submit #edit-post": "update"')}/, view
     end
-    
+
     assert_file "#{backbone_path}/views/posts/post_view.js.coffee" do |view|
       assert_match /class Dummy.Views.Posts.PostView extends Backbone.View/, view
       assert_match /#{Regexp.escape('this.template(this.options.model.toJSON() )')}/, view
       assert_match /#{Regexp.escape('JST["backbone/templates/posts/post"]')}/, view
     end
   end
-  
+
   test "generate view files for model with two words" do
     run_generator %w(BlogPost title:string content:string)
-    
+
     assert_file "#{backbone_path}/views/blog_posts/index_view.js.coffee" do |view|
       assert_match /#{Regexp.escape('JST["backbone/templates/blog_posts/index"]')}/, view
-      assert_match /#{Regexp.escape('this.template(blogPosts: this.options.blogPosts.toJSON() ))')}/, view
+      assert_match /#{Regexp.escape('this.template(blogPosts: this.options.blog_posts.toJSON() ))')}/, view
       assert_match /#{Regexp.escape("new Dummy.Views.BlogPosts.BlogPostView({model : blogPost})")}/, view
     end
-    
+
     assert_file "#{backbone_path}/views/blog_posts/show_view.js.coffee" do |view|
       assert_match /class Dummy.Views.BlogPosts.ShowView extends Backbone.View/, view
       assert_match /#{Regexp.escape('this.template(this.options.model.toJSON() )')}/, view
       assert_match /#{Regexp.escape('template: JST["backbone/templates/blog_posts/show"]')}/, view
     end
-    
+
     assert_file "#{backbone_path}/views/blog_posts/new_view.js.coffee" do |view|
       assert_match /class Dummy.Views.BlogPosts.NewView extends Backbone.View/, view
       assert_match /#{Regexp.escape('this.template(@options.model.toJSON() )')}/, view
       assert_match /#{Regexp.escape('JST["backbone/templates/blog_posts/new"]')}/, view
       assert_match /#{Regexp.escape('"submit #new-blog_post": "save"')}/, view
     end
-    
+
     assert_file "#{backbone_path}/views/blog_posts/edit_view.js.coffee" do |view|
       assert_match /class Dummy.Views.BlogPosts.EditView extends Backbone.View/, view
       assert_match /#{Regexp.escape('JST["backbone/templates/blog_posts/edit"]')}/, view
       assert_match /#{Regexp.escape('"submit #edit-blog_post": "update"')}/, view
     end
-    
+
     assert_file "#{backbone_path}/views/blog_posts/blog_post_view.js.coffee" do |view|
       assert_match /class Dummy.Views.BlogPosts.BlogPostView extends Backbone.View/, view
       assert_match /#{Regexp.escape('this.template(this.options.model.toJSON() )')}/, view
       assert_match /#{Regexp.escape('JST["backbone/templates/blog_posts/blog_post"]')}/, view
     end
   end
-  
+
   test "generate template files" do
     run_generator
-     
+
     assert_file "#{backbone_path}/templates/posts/index.jst.ejs"
-    
+
     assert_file "#{backbone_path}/templates/posts/new.jst.ejs" do |view|
       assert_match /#{Regexp.escape('<form id="new-post" name="post">')}/, view
     end
-    
+
     assert_file "#{backbone_path}/templates/posts/edit.jst.ejs" do |view|
       assert_match /#{Regexp.escape('<form id="edit-post" name="post">')}/, view
     end
-    
+
     assert_file "#{backbone_path}/templates/posts/show.jst.ejs"
     assert_file "#{backbone_path}/templates/posts/post.jst.ejs"
   end
-   
+
   test "generate template files for model with two words" do
     run_generator %w(BlogPost title:string content:string)
 
@@ -138,29 +138,29 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     assert_file "#{backbone_path}/templates/blog_posts/show.jst.ejs"
     assert_file "#{backbone_path}/templates/blog_posts/blog_post.jst.ejs"
   end
-   
+
   test "backbone model generator is invoked" do
     run_generator
-    
+
     assert_file "#{backbone_path}/models/post.js.coffee" do |model|
       assert_match /url: '\/posts'/, model
       assert_match /paramRoot: 'post'/, model
-      
+
       assert_match /title: null/, model
       assert_match /content: null/, model
     end
   end
-  
+
   test "backbone model generator is invoked for model with two words" do
     run_generator %w(BlogPost title:string content:string)
-    
+
     assert_file "#{backbone_path}/models/blog_post.js.coffee" do |model|
       assert_match /url: '\/blog_posts'/, model
       assert_match /paramRoot: 'blog_post'/, model
-      
+
       assert_match /title: null/, model
       assert_match /content: null/, model
     end
   end
-  
+
 end


### PR DESCRIPTION
Fixed bug preventing index view for model with two words from working in browser.

For example, with scaffold generated code, a javascript error occurred saying this.option.blogPost did not exist.

Changing @option.blogPost to @option.blog_post in scaffold generated router.js.coffee and index_view.coffee fixed the problem.
