### PR TITLE
remove whitespace in generators

### DIFF
--- a/lib/generators/backbone/model/templates/model.coffee
+++ b/lib/generators/backbone/model/templates/model.coffee
@@ -5,7 +5,7 @@ class <%= model_namespace %> extends Backbone.Model
 <% attributes.each do |attribute| -%>
     <%= attribute.name %>: null
 <% end -%>
-  
+
 class <%= collection_namespace %>Collection extends Backbone.Collection
   model: <%= model_namespace %>
   url: '<%= route_url %>'

--- a/lib/generators/backbone/router/templates/router.coffee
+++ b/lib/generators/backbone/router/templates/router.coffee
@@ -1,14 +1,14 @@
 class <%= router_namespace %>Router extends Backbone.Router
   initialize: (options) ->
-    
+
   routes:
   <% actions.each do |action| -%>
   "/<%= action %>": "<%= action %>"
   <% end -%>
-  
+
 <% actions.each do |action| -%>
   <%= action %>: ->
     @view = new <%= "#{view_namespace}.#{action.camelize}View()" %>
     $("#<%= plural_name %>").html(@view.render().el)
-    
+
 <% end -%>

--- a/lib/generators/backbone/router/templates/view.coffee
+++ b/lib/generators/backbone/router/templates/view.coffee
@@ -2,7 +2,7 @@
 
 class <%= view_namespace %>.<%= @action.camelize %>View extends Backbone.View
   template: JST["<%= jst @action %>"]
-       
+
   render: ->
     $(@el).html(@template())
     return this

--- a/lib/generators/backbone/scaffold/templates/model.coffee
+++ b/lib/generators/backbone/scaffold/templates/model.coffee
@@ -5,7 +5,7 @@ class <%= model_namespace %> extends Backbone.Model
 <% attributes.each do |attribute| -%>
     <%= attribute.name %>: null
 <% end -%>
-  
+
 class <%= collection_namespace %>Collection extends Backbone.Collection
   model: <%= model_namespace %>
   url: '<%= route_url %>'

--- a/lib/generators/backbone/scaffold/templates/router.coffee
+++ b/lib/generators/backbone/scaffold/templates/router.coffee
@@ -20,13 +20,12 @@ class <%= router_namespace %>Router extends Backbone.Router
 
   show: (id) ->
     <%= singular_name %> = @<%= plural_name %>.get(id)
-    
+
     @view = new <%= "#{view_namespace}.ShowView(model: #{singular_name})" %>
     $("#<%= plural_name %>").html(@view.render().el)
-    
+
   edit: (id) ->
     <%= singular_name %> = @<%= plural_name %>.get(id)
 
     @view = new <%= "#{view_namespace}.EditView(model: #{singular_name})" %>
     $("#<%= plural_name %>").html(@view.render().el)
-  

--- a/lib/generators/backbone/scaffold/templates/views/edit_view.coffee
+++ b/lib/generators/backbone/scaffold/templates/views/edit_view.coffee
@@ -2,23 +2,23 @@
 
 class <%= view_namespace %>.EditView extends Backbone.View
   template : JST["<%= jst 'edit' %>"]
-  
+
   events :
     "submit #edit-<%= singular_name %>" : "update"
-    
+
   update : (e) ->
     e.preventDefault()
     e.stopPropagation()
-    
+
     @model.save(null,
       success : (<%= singular_name %>) =>
         @model = <%= singular_name %>
         window.location.hash = "/#{@model.id}"
     )
-    
+
   render : ->
     $(this.el).html(this.template(@model.toJSON() ))
-    
+
     this.$("form").backboneLink(@model)
-    
+
     return this

--- a/lib/generators/backbone/scaffold/templates/views/index_view.coffee
+++ b/lib/generators/backbone/scaffold/templates/views/index_view.coffee
@@ -2,21 +2,21 @@
 
 class <%= view_namespace %>.IndexView extends Backbone.View
   template: JST["<%= jst 'index' %>"]
-    
+
   initialize: () ->
     _.bindAll(this, 'addOne', 'addAll', 'render')
-    
+
     @options.<%= plural_model_name %>.bind('reset', @addAll)
-   
+
   addAll: () ->
     @options.<%= plural_model_name %>.each(@addOne)
-  
+
   addOne: (<%= singular_model_name %>) ->
     view = new <%= view_namespace %>.<%= singular_name.camelize %>View({model : <%= singular_model_name %>})
     @$("tbody").append(view.render().el)
-       
+
   render: ->
     $(@el).html(@template(<%= plural_model_name %>: @options.<%= plural_model_name %>.toJSON() ))
     @addAll()
-    
+
     return this

--- a/lib/generators/backbone/scaffold/templates/views/model_view.coffee
+++ b/lib/generators/backbone/scaffold/templates/views/model_view.coffee
@@ -2,18 +2,18 @@
 
 class <%= view_namespace %>.<%= singular_name.camelize %>View extends Backbone.View
   template: JST["<%= jst singular_name %>"]
-  
+
   events:
     "click .destroy" : "destroy"
-      
+
   tagName: "tr"
-  
+
   destroy: () ->
     @model.destroy()
     this.remove()
-    
+
     return false
-    
+
   render: ->
-    $(this.el).html(@template(@model.toJSON() ))    
+    $(this.el).html(@template(@model.toJSON() ))
     return this

--- a/lib/generators/backbone/scaffold/templates/views/new_view.coffee
+++ b/lib/generators/backbone/scaffold/templates/views/new_view.coffee
@@ -1,11 +1,11 @@
 <%= view_namespace %> ||= {}
 
-class <%= view_namespace %>.NewView extends Backbone.View    
+class <%= view_namespace %>.NewView extends Backbone.View
   template: JST["<%= jst 'new' %>"]
-  
+
   events:
     "submit #new-<%= singular_name %>": "save"
-    
+
   constructor: (options) ->
     super(options)
     @model = new @collection.model()
@@ -13,25 +13,25 @@ class <%= view_namespace %>.NewView extends Backbone.View
     @model.bind("change:errors", () =>
       this.render()
     )
-    
+
   save: (e) ->
     e.preventDefault()
     e.stopPropagation()
-      
+
     @model.unset("errors")
-    
-    @collection.create(@model.toJSON(), 
+
+    @collection.create(@model.toJSON(),
       success: (<%= singular_name %>) =>
         @model = <%= singular_name %>
         window.location.hash = "/#{@model.id}"
-        
+
       error: (<%= singular_name %>, jqXHR) =>
         @model.set({errors: $.parseJSON(jqXHR.responseText)})
     )
-    
+
   render: ->
     $(this.el).html(@template(@model.toJSON() ))
-    
+
     this.$("form").backboneLink(@model)
-    
+
     return this

--- a/lib/generators/backbone/scaffold/templates/views/show_view.coffee
+++ b/lib/generators/backbone/scaffold/templates/views/show_view.coffee
@@ -2,7 +2,7 @@
 
 class <%= view_namespace %>.ShowView extends Backbone.View
   template: JST["<%= jst 'show' %>"]
-   
+
   render: ->
     $(this.el).html(@template(@model.toJSON() ))
     return this


### PR DESCRIPTION
Bit of a pedantic commit, but my editor makes whitespace very obvious!

![](http://f.cl.ly/items/2Y1E3g3g3l1X1z3J2R1W/Screen%20Shot%202011-09-04%20at%2011.37.08.png)

This commit removes all whitespace from the generators.
