### PR TITLE
Added missing quotation marks around an <input>'s value attribute.

### DIFF
--- a/lib/generators/backbone/scaffold/templates/templates/edit.jst
+++ b/lib/generators/backbone/scaffold/templates/templates/edit.jst
@@ -4,7 +4,7 @@
 <% attributes.each do |attribute| -%>
   <div class="field">
     <label for="<%= attribute.name %>"> <%= attribute.name %>:</label>
-    <input type="text" name="<%= attribute.name %>" id="<%= attribute.name %>" value="<%= attribute.name %>" >
+    <input type="text" name="<%= attribute.name %>" id="<%= attribute.name %>" value="<%%= <%= attribute.name %> %>" >
   </div>
 
 <% end -%>


### PR DESCRIPTION
This caused a bug where an input's real value would not be displayed correctly as a result of mal-formed HTML, for example:

Buggy HTML:

<input value="Foo" Bar>

Correct HTML:

<input  value="Foo Bar">
