### PR TITLE
fixed datalink binding for checkboxes

### DIFF
--- a/vendor/assets/javascripts/backbone_datalink.js
+++ b/vendor/assets/javascripts/backbone_datalink.js
@@ -6,13 +6,19 @@
         el = $(this);
         name = el.attr("name");
         model.bind("change:" + name, function() {
-          return el.val(model.get(name));
+          if(el.is(":checkbox")){
+            return el.attr("checked", !!model.get(name));
+          }
+          else{
+            return el.val(model.get(name));
+          }
         });
         return $(this).bind("change", function() {
-          var attrs;
+          var attrs, newValue;
           el = $(this);
           attrs = {};
-          attrs[el.attr("name")] = el.val();
+          newValue = el.is(":checkbox") ? el.is(":checked") : el.val();
+          attrs[el.attr("name")] = newValue;
           return model.set(attrs);
         });
       });


### PR DESCRIPTION
The datalink code wasn't working as expected for checkboxes, that's because checkboxes don't work like other input elements. This patch fixes that by forcing the checkbox to a boolean value.
