### PR TITLE
Trigger sync:start, sync:end events

### DIFF
--- a/vendor/assets/javascripts/backbone_rails_sync.js
+++ b/vendor/assets/javascripts/backbone_rails_sync.js
@@ -51,7 +51,19 @@
     if (params.type !== 'GET') {
       params.processData = false;
     }
-    
+    // Trigger the sync events
+    var success = options.success;
+    var error = options.error;
+    options.success = function(resp, status, xhr) {
+      model.trigger('sync:end');
+      return success(resp, status, xhr);
+    };
+    options.error = function(resp, status, xhr){
+      model.trigger('sync:end');
+      return error(resp, status, xhr);
+    };
+    model.trigger('sync:start');
+
     // Make the request.
     return $.ajax(params);
   }


### PR DESCRIPTION
This allows binding directly to the model:

``` coffee
@model.bind 'sync:start', @showNotification
@model.bind 'sync:end', @hideNotification
```
