### PR TITLE
Fix router template of scaffold generator for models with name compose of more than 1 word

### DIFF
--- a/lib/generators/backbone/scaffold/templates/router.coffee
+++ b/lib/generators/backbone/scaffold/templates/router.coffee
@@ -11,21 +11,21 @@ class <%= router_namespace %>Router extends Backbone.Router
     ".*"        : "index"
 
   new<%= class_name %>: ->
-    @view = new <%= "#{view_namespace}.NewView(collection: @#{plural_name})" %>
+    @view = new <%= "#{view_namespace}.NewView(collection: @#{plural_model_name})" %>
     $("#<%= plural_name %>").html(@view.render().el)
 
   index: ->
-    @view = new <%= "#{view_namespace}.IndexView(#{plural_name}: @#{plural_name})" %>
+    @view = new <%= "#{view_namespace}.IndexView(#{plural_model_name}: @#{plural_model_name})" %>
     $("#<%= plural_name %>").html(@view.render().el)
 
   show: (id) ->
-    <%= singular_name %> = @<%= plural_name %>.get(id)
+    <%= singular_name %> = @<%= plural_model_name %>.get(id)
 
     @view = new <%= "#{view_namespace}.ShowView(model: #{singular_name})" %>
     $("#<%= plural_name %>").html(@view.render().el)
 
   edit: (id) ->
-    <%= singular_name %> = @<%= plural_name %>.get(id)
+    <%= singular_name %> = @<%= plural_model_name %>.get(id)
 
     @view = new <%= "#{view_namespace}.EditView(model: #{singular_name})" %>
     $("#<%= plural_name %>").html(@view.render().el)


### PR DESCRIPTION
One example:

``` ruby
rails g scaffold TestCase name:string content:string
rake db:migrate
rails g backbone:scaffold TestCase name:string content:string
```

the router gets generated would be like:

``` ruby
class AppName.Routers.TestCasesRouter extends Backbone.Router
initialize: (options) ->
@testCases = new AppName.Collections.TestCasesCollection()
@testCases.reset options.testCases
...
newTestCase: ->
@view = new AppName.Views.TestCases.NewView(collection: @test_case)
...
index: ->
@view = new AppName.Views.TestCases.IndexView(test_case: @test_case) 
```

While it should stick to camel name convention for js code, use testCase instead of test_case. And there're some other part of the code is using something like options.testCases but here you passed in test_case hence the problem like 'bind' is not a function on 'undefined' would happen.
