### PR TITLE
strip all trailing whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Follow [@TheRyanFitz on Twitter](http://twitter.com/#!/TheRyanFitz). Tweet some 
 ## Rails 3.1 setup
 This gem requires the use of rails 3.1, coffeescript and the new rails asset pipeline provided by sprockets.
 
-This gem vendors the latest version of underscore.js and backbone.js for Rails 3.1 and greater. The files will be added to the asset pipeline and available for you to use. 
-    
+This gem vendors the latest version of underscore.js and backbone.js for Rails 3.1 and greater. The files will be added to the asset pipeline and available for you to use.
+
 ### Installation
 
 In your Gemfile, add this line:
 
     gem "rails-backbone"
-  
+
 Then run the following commands:
 
     bundle install
@@ -23,34 +23,34 @@ Then run the following commands:
 ### Layout and namespacing
 
 Running `rails g backbone:install` will create the following directory structure under `app/assets/javascripts/backbone`:
-  
+
     routers/
     models/
     templates/
     views/
-    
+
 It will also create a toplevel app_name.coffee file to setup namespacing and setup initial requires.
-    
+
 ## Generators
-backbone-rails provides 3 simple generators to help get you started using backbone.js with rails 3.1. 
+backbone-rails provides 3 simple generators to help get you started using backbone.js with rails 3.1.
 The generators will only create client side code (javascript).
 
 ### Model Generator
 
     rails g backbone:model
-    
+
 This generator creates a backbone model and collection inside `app/assets/javascript/backbone/models` to be used to talk to the rails backend.
 
 ### Routers
-    
+
     rails g backbone:router
-    
+
 This generator creates a backbone router with corresponding views and templates for the given actions provided.
 
 ### Scaffolding
 
     rails g backbone:scaffold
-    
+
 This generator creates a router, views, templates, model and collection to create a simple crud single page app
 
 ## Example Usage
@@ -70,8 +70,8 @@ Install the gem and generate scaffolding.
     rails g scaffold Post title:string content:string
     rake db:migrate
     rails g backbone:scaffold Post title:string content:string
-    
-You now have installed the backbone-rails gem, setup a default directory structure for your frontend backbone code. 
+
+You now have installed the backbone-rails gem, setup a default directory structure for your frontend backbone code.
 Then you generated the usual rails server side crud scaffolding and finally generated backbone.js code to provide a simple single page crud app.
 You have one last step:
 
@@ -86,7 +86,7 @@ Edit your posts index view `app/views/posts/index.html.erb` with the following c
         Backbone.history.start();
       });
     </script>
-    
+
 If you prefer haml, this is equivalent to inserting the following code into `app/views/posts/index.html.haml`:
 
     :javascript
@@ -96,6 +96,6 @@ If you prefer haml, this is equivalent to inserting the following code into `app
         Backbone.history.start();
       });
 
-    
+
 Now start your server `rails s` and browse to [localhost:3000/posts](http://localhost:3000/posts)
 You should now have a fully functioning single page crud app for Post models.

--- a/Rakefile
+++ b/Rakefile
@@ -34,7 +34,7 @@ namespace :backbone do
       'underscore.js'=>'https://github.com/documentcloud/underscore/raw/master/underscore.js',
       'backbone.js' => 'https://github.com/documentcloud/backbone/raw/master/backbone.js'
     }
-    
+
     vendor_dir = "vendor/assets/javascripts"
 
     require 'open-uri'

--- a/backbone-rails.gemspec
+++ b/backbone-rails.gemspec
@@ -6,14 +6,14 @@ Gem::Specification.new do |s|
   s.authors     = ["Ryan Fitzgerald", "Code Brew Studios"]
   s.email       = ["ryan@codebrewstudios.com"]
   s.homepage    = "http://github.com/codebrew/backbone-rails"
-  
+
   s.summary = "Use backbone.js with rails 3.1"
   s.description = "Quickly setup backbone.js for use with rails 3.1. Generators are provided to quickly get started."
   s.files = Dir["lib/**/*"] + Dir["vendor/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
-  
+
   s.add_dependency('rails', '~> 3.1.0')
   s.add_dependency('coffee-script', '~> 2.2.0')
   s.add_dependency('ejs', '~> 1.0.0')
-  
+
   s.require_paths = ['lib']
 end

--- a/lib/generators/backbone/install/install_generator.rb
+++ b/lib/generators/backbone/install/install_generator.rb
@@ -4,31 +4,31 @@ module Backbone
   module Generators
     class InstallGenerator < Rails::Generators::Base
       include Backbone::Generators::ResourceHelpers
-      
+
       source_root File.expand_path("../templates", __FILE__)
-  
+
       desc "This generator installs backbone.js with a default folder layout in app/assets/javascripts/backbone"
-          
+
       class_option :skip_git, :type => :boolean, :aliases => "-G", :default => false,
                               :desc => "Skip Git ignores and keeps"
-                                      
+
       def inject_backbone
         inject_into_file "app/assets/javascripts/application.js", :before => "//= require_tree" do
           "//= require underscore\n//= require backbone\n//= require backbone_rails_sync\n//= require backbone_datalink\n//= require backbone/#{application_name.underscore}\n"
         end
       end
-    
+
       def create_dir_layout
         %W{routers models views templates}.each do |dir|
-          empty_directory "app/assets/javascripts/backbone/#{dir}" 
+          empty_directory "app/assets/javascripts/backbone/#{dir}"
           create_file "app/assets/javascripts/backbone/#{dir}/.gitkeep" unless options[:skip_git]
         end
       end
-    
+
       def create_app_file
         template "app.coffee", "app/assets/javascripts/backbone/#{application_name.underscore}.js.coffee"
       end
-     
+
     end
   end
 end

--- a/lib/generators/backbone/model/model_generator.rb
+++ b/lib/generators/backbone/model/model_generator.rb
@@ -4,16 +4,16 @@ module Backbone
   module Generators
     class ModelGenerator < Rails::Generators::NamedBase
       include Backbone::Generators::ResourceHelpers
-        
+
       source_root File.expand_path("../templates", __FILE__)
       desc "This generator creates a backbone model"
-      
+
       argument :attributes, :type => :array, :default => [], :banner => "field:type field:type"
-    
+
       def create_backbone_model
         template "model.coffee", "#{backbone_path}/models/#{file_name}.js.coffee"
       end
-    
+
     end
   end
 end

--- a/lib/generators/backbone/resource_helpers.rb
+++ b/lib/generators/backbone/resource_helpers.rb
@@ -1,43 +1,43 @@
 module Backbone
   module Generators
     module ResourceHelpers
-      
+
       def backbone_path
         "app/assets/javascripts/backbone"
       end
-      
+
       def model_namespace
         [js_app_name, "Models", class_name].join(".")
       end
-      
+
       def singular_model_name
         uncapitalize singular_name.camelize
       end
-      
+
       def plural_model_name
         uncapitalize(plural_name.camelize)
       end
-      
+
       def collection_namespace
         [js_app_name, "Collections", plural_name.camelize].join(".")
       end
-      
+
       def view_namespace
         [js_app_name, "Views", plural_name.camelize].join(".")
       end
-      
+
       def router_namespace
         [js_app_name, "Routers", plural_name.camelize].join(".")
       end
-      
+
       def jst(action)
         "backbone/templates/#{plural_name}/#{action}"
       end
-      
+
       def js_app_name
         application_name.camelize
       end
-      
+
       def application_name
         if defined?(Rails) && Rails.application
           Rails.application.class.name.split('::').first
@@ -45,11 +45,11 @@ module Backbone
           "application"
         end
       end
-      
+
       def uncapitalize(str)
           str[0, 1].downcase + str[1..-1]
       end
-      
+
     end
   end
 end

--- a/lib/generators/backbone/router/router_generator.rb
+++ b/lib/generators/backbone/router/router_generator.rb
@@ -4,17 +4,17 @@ module Backbone
   module Generators
     class RouterGenerator < Rails::Generators::NamedBase
       include Backbone::Generators::ResourceHelpers
-      
+
       source_root File.expand_path("../templates", __FILE__)
       desc "This generator creates a backbone router with views and templates for the provided actions"
-      
+
       argument :actions, :type => :array, :default => [], :banner => "action action"
-      
+
       RESERVED_JS_WORDS = %W{
-        break case catch continue debugger default delete do else finally for 
-        function if in instanceof new return switch this throw try typeof var void while with 
+        break case catch continue debugger default delete do else finally for
+        function if in instanceof new return switch this throw try typeof var void while with
       }
-      
+
       def validate_no_reserved_words
         actions.each do |action|
           if RESERVED_JS_WORDS.include? action
@@ -23,17 +23,17 @@ module Backbone
           end
         end
       end
-      
-      def create_router_files 
+
+      def create_router_files
         template 'router.coffee', File.join(backbone_path, "routers", class_path, "#{file_name}_router.js.coffee")
       end
-      
+
       def create_view_files
          actions.each do |action|
            @action = action
            @view_path = File.join(backbone_path, "views", plural_name, "#{action}_view.js.coffee")
            @jst_path = File.join(backbone_path,"templates", plural_name, "#{action}.jst.ejs")
-           
+
            template "view.coffee", @view_path
            template "template.jst", @jst_path
          end

--- a/lib/generators/backbone/scaffold/scaffold_generator.rb
+++ b/lib/generators/backbone/scaffold/scaffold_generator.rb
@@ -3,29 +3,29 @@ require 'generators/backbone/model/model_generator'
 module Backbone
   module Generators
     class ScaffoldGenerator < ModelGenerator
-      
+
       source_root File.expand_path("../templates", __FILE__)
       desc "This generator creates the client side crud scaffolding"
-      
-      def create_router_files 
+
+      def create_router_files
         template 'router.coffee', File.join(backbone_path, "routers", class_path, "#{plural_name}_router.js.coffee")
       end
-      
+
       def create_view_files
         available_views.each do |view|
           template "views/#{view}_view.coffee", File.join(backbone_path, "views", plural_name, "#{view}_view.js.coffee")
-          template "templates/#{view}.jst", File.join(backbone_path, "templates", plural_name, "#{view}.jst.ejs")       
+          template "templates/#{view}.jst", File.join(backbone_path, "templates", plural_name, "#{view}.jst.ejs")
         end
-        
+
         template "views/model_view.coffee", File.join(backbone_path, "views", plural_name, "#{singular_name}_view.js.coffee")
-        template "templates/model.jst", File.join(backbone_path, "templates", plural_name, "#{singular_name}.jst.ejs") 
+        template "templates/model.jst", File.join(backbone_path, "templates", plural_name, "#{singular_name}.jst.ejs")
       end
-      
+
       protected
         def available_views
           %w(index show new edit)
         end
-        
+
     end
   end
 end

--- a/test/backbone-rails_test.rb
+++ b/test/backbone-rails_test.rb
@@ -4,11 +4,11 @@ class BackboneRailsTest < ActiveSupport::TestCase
   def setup
     @app = Dummy::Application
   end
-  
+
   test "backbone.js is found as an asset" do
     assert_not_nil @app.assets["backbone"]
   end
-  
+
   test "underscore.js is found as an asset" do
     assert_not_nil @app.assets["underscore"]
   end

--- a/test/dummy/app/assets/stylesheets/application.css
+++ b/test/dummy/app/assets/stylesheets/application.css
@@ -1,5 +1,5 @@
 /*
  * FIXME: Introduce SCSS & Sprockets
  *= require_self
- *= require_tree . 
+ *= require_tree .
 */

--- a/test/dummy/app/assets/stylesheets/home.css.scss
+++ b/test/dummy/app/assets/stylesheets/home.css.scss
@@ -1,4 +1,4 @@
-/* 
+/*
   Place all the styles related to the matching controller here.
   They will automatically be included in application.css.
   You can use Sass (SCSS) here: http://sass-lang.com/

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -2,7 +2,7 @@ Dummy::Application.routes.draw do
   resources :posts
 
   get "home/index"
-  
+
   root :to => "posts#index"
 
   # The priority is based upon order of creation:

--- a/test/generators/generators_test_helper.rb
+++ b/test/generators/generators_test_helper.rb
@@ -5,9 +5,9 @@ module GeneratorsTestHelper
       setup :prepare_destination
     end
   end
-  
+
   def backbone_path
     "app/assets/javascripts/backbone"
   end
-  
+
 end

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -6,67 +6,67 @@ require 'mocha'
 class InstallGeneratorTest < Rails::Generators::TestCase
   include GeneratorsTestHelper
   tests Backbone::Generators::InstallGenerator
-  
+
   def setup
     mkdir_p "#{destination_root}/app/assets/javascripts"
     cp fixture("application.js"), "#{destination_root}/app/assets/javascripts"
     Rails.application.class.stubs(:name).returns("Dummy::Application")
-    
+
     super
   end
-  
+
   test "Assert application coffeescript file is created" do
     run_generator
-    
+
     assert_file "#{backbone_path}/dummy.js.coffee", /window\.Dummy/
   end
-  
+
   test "Assert application coffeescript file is created for two word application name" do
     Rails.application.class.stubs(:name).returns("FooBar::Application")
     run_generator
-    
+
     assert_file "#{backbone_path}/foo_bar.js.coffee", /window\.FooBar/
   end
-  
+
   test "Assert application require is properly setup for two word application name" do
     Rails.application.class.stubs(:name).returns("FooBar::Application")
     run_generator
-    
+
     assert_file "app/assets/javascripts/application.js", /require backbone\/foo_bar/
   end
-  
+
   test "Assert backbone directory structure is created" do
     run_generator
-    
+
     %W{routers models views templates}.each do |dir|
       assert_directory "#{backbone_path}/#{dir}"
       assert_file "#{backbone_path}/#{dir}/.gitkeep"
     end
   end
-  
+
   test "Assert no gitkeep files are created when skipping git" do
     run_generator [destination_root, "--skip-git"]
-    
+
     %W{routers models views templates}.each do |dir|
       assert_directory "#{backbone_path}/#{dir}"
       assert_no_file "#{backbone_path}/#{dir}/.gitkeep"
     end
   end
-  
+
   test "Assert application.js require underscore, backbone and backbone_rails_sync and dummy.js" do
     run_generator
-    
+
     assert_file "app/assets/javascripts/application.js" do |application|
       assert_match /require backbone\/dummy/, application
-      
+
       %W{underscore backbone backbone_rails_sync backbone_datalink}.each do |require|
         assert_match /#{require}/, application
       end
     end
-  end  
-  
+  end
+
   def fixture(file)
     File.expand_path("fixtures/#{file}", File.dirname(__FILE__))
   end
-  
+
 end

--- a/test/generators/model_generator_test.rb
+++ b/test/generators/model_generator_test.rb
@@ -5,45 +5,45 @@ require "generators/backbone/model/model_generator"
 class ModelGeneratorTest < Rails::Generators::TestCase
   include GeneratorsTestHelper
   tests Backbone::Generators::ModelGenerator
-  
+
   test "simple model" do
     run_generator %w(Post title:string content:string)
-    
+
     assert_file "#{backbone_path}/models/post.js.coffee" do |model|
       model_class = Regexp.escape("class Dummy.Models.Post extends Backbone.Model")
       collection_class = Regexp.escape("class Dummy.Collections.PostsCollection extends Backbone.Collection")
-      
+
       assert_match /#{model_class}/, model
       assert_match /#{collection_class}/, model
-      
+
       assert_match /paramRoot: 'post'/, model
       assert_match /url: '\/posts'/, model
-      
+
       assert_match /defaults:/, model
       assert_match /title: null/, model
       assert_match /content: null/, model
     end
-    
+
   end
-  
+
   test "two word model is camelcased" do
     run_generator %w(BlogPost title:string content:string)
-    
+
     assert_file "#{backbone_path}/models/blog_post.js.coffee" do |model|
       model_class = Regexp.escape("class Dummy.Models.BlogPost extends Backbone.Model")
       collection_class = Regexp.escape("class Dummy.Collections.BlogPostsCollection extends Backbone.Collection")
-      
+
       assert_match /#{model_class}/, model
       assert_match /#{collection_class}/, model
-      
+
       assert_match /paramRoot: 'blog_post'/, model
       assert_match /url: '\/blog_posts'/, model
-      
+
       assert_match /defaults:/, model
       assert_match /title: null/, model
       assert_match /content: null/, model
     end
-    
+
   end
-  
+
 end

--- a/test/generators/router_generator_test.rb
+++ b/test/generators/router_generator_test.rb
@@ -5,36 +5,36 @@ require "generators/backbone/router/router_generator"
 class RouterGeneratorTest < Rails::Generators::TestCase
   include GeneratorsTestHelper
   tests Backbone::Generators::RouterGenerator
-  
+
   test "simple router with two actions" do
     run_generator ["Posts", "index", "edit"]
-    
+
     assert_file "#{backbone_path}/routers/posts_router.js.coffee" do |router|
       assert_match /Dummy.Routers.PostsRouter extends Backbone.Router/, router
     end
-    
+
     %W{index edit}.each do |action|
       assert_file "#{backbone_path}/views/posts/#{action}_view.js.coffee"
       assert_file "#{backbone_path}/templates/posts/#{action}.jst.ejs"
     end
   end
-  
+
   test "camelize router names containing two words" do
     run_generator ["BlogPosts", "index", "edit"]
-    
+
     assert_file "#{backbone_path}/routers/blog_posts_router.js.coffee" do |router|
       assert_match /Dummy.Routers.BlogPostsRouter extends Backbone.Router/, router
     end
-    
+
     %W{index edit}.each do |action|
       assert_file "#{backbone_path}/views/blog_posts/#{action}_view.js.coffee"
       assert_file "#{backbone_path}/templates/blog_posts/#{action}.jst.ejs"
     end
   end
-  
+
   test "raises an error when an action is a javascript reserved word" do
     content = capture(:stderr){ run_generator ["Posts", "new"] }
     assert_equal "The name 'new' is reserved by javascript Please choose an alternative action name and run this generator again.\n", content
   end
-  
+
 end

--- a/test/generators/scaffold_generator_test.rb
+++ b/test/generators/scaffold_generator_test.rb
@@ -6,50 +6,50 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
   include GeneratorsTestHelper
   tests Backbone::Generators::ScaffoldGenerator
   arguments %w(Post title:string content:string)
-  
+
   test "generate router scaffolding" do
     run_generator
-    
+
     assert_file "#{backbone_path}/routers/posts_router.js.coffee" do |router|
       assert_match /class Dummy.Routers.PostsRouter extends Backbone.Router/, router
       assert_match /newPost: ->/, router
       assert_match /@posts.reset options.posts/, router
-      
+
       %w(NewView IndexView ShowView EditView).each do |view|
         assert_match /new Dummy.Views.Posts.#{view}/, router
       end
     end
   end
-  
+
   test "generate router scaffolding for model with two words" do
     run_generator %w(BlogPost title:string content:string)
-    
+
     assert_file "#{backbone_path}/routers/blog_posts_router.js.coffee" do |router|
       assert_match /class Dummy.Routers.BlogPostsRouter extends Backbone.Router/, router
       assert_match /newBlogPost: ->/, router
       assert_match /@blogPosts.reset options.blogPosts/, router
-      
+
       %w(NewView IndexView ShowView EditView).each do |view|
         assert_match /new Dummy.Views.BlogPosts.#{view}/, router
       end
     end
   end
-  
+
   test "generate view files" do
     run_generator
-    
+
     assert_file "#{backbone_path}/views/posts/index_view.js.coffee" do |view|
       assert_match /#{Regexp.escape('JST["backbone/templates/posts/index"]')}/, view
       assert_match /#{Regexp.escape('@template(posts: @options.posts.toJSON() ))')}/, view
       assert_match /#{Regexp.escape("new Dummy.Views.Posts.PostView({model : post})")}/, view
     end
-    
+
     assert_file "#{backbone_path}/views/posts/show_view.js.coffee" do |view|
       assert_match /class Dummy.Views.Posts.ShowView extends Backbone.View/, view
       assert_match /#{Regexp.escape('@template(@model.toJSON() )')}/, view
       assert_match /#{Regexp.escape('template: JST["backbone/templates/posts/show"]')}/, view
     end
-    
+
     assert_file "#{backbone_path}/views/posts/new_view.js.coffee" do |view|
       assert_match /class Dummy.Views.Posts.NewView extends Backbone.View/, view
       assert_match /#{Regexp.escape('@template(@model.toJSON() )')}/, view
@@ -58,36 +58,36 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
       assert_match /#{Regexp.escape('success: (post) =>')}/, view
       assert_match /#{Regexp.escape('@model = post')}/, view
     end
-    
+
     assert_file "#{backbone_path}/views/posts/edit_view.js.coffee" do |view|
       assert_match /class Dummy.Views.Posts.EditView extends Backbone.View/, view
       assert_match /#{Regexp.escape('JST["backbone/templates/posts/edit"]')}/, view
       assert_match /#{Regexp.escape('"submit #edit-post" : "update"')}/, view
       assert_match /#{Regexp.escape('success : (post) =>')}/, view
     end
-    
+
     assert_file "#{backbone_path}/views/posts/post_view.js.coffee" do |view|
       assert_match /class Dummy.Views.Posts.PostView extends Backbone.View/, view
       assert_match /#{Regexp.escape('@template(@model.toJSON() )')}/, view
       assert_match /#{Regexp.escape('JST["backbone/templates/posts/post"]')}/, view
     end
   end
-  
+
   test "generate view files for model with two words" do
     run_generator %w(BlogPost title:string content:string)
-    
+
     assert_file "#{backbone_path}/views/blog_posts/index_view.js.coffee" do |view|
       assert_match /#{Regexp.escape('JST["backbone/templates/blog_posts/index"]')}/, view
       assert_match /#{Regexp.escape('@template(blogPosts: @options.blogPosts.toJSON() ))')}/, view
       assert_match /#{Regexp.escape("new Dummy.Views.BlogPosts.BlogPostView({model : blogPost})")}/, view
     end
-    
+
     assert_file "#{backbone_path}/views/blog_posts/show_view.js.coffee" do |view|
       assert_match /class Dummy.Views.BlogPosts.ShowView extends Backbone.View/, view
       assert_match /#{Regexp.escape('@template(@model.toJSON() )')}/, view
       assert_match /#{Regexp.escape('template: JST["backbone/templates/blog_posts/show"]')}/, view
     end
-    
+
     assert_file "#{backbone_path}/views/blog_posts/new_view.js.coffee" do |view|
       assert_match /class Dummy.Views.BlogPosts.NewView extends Backbone.View/, view
       assert_match /#{Regexp.escape('@template(@model.toJSON() )')}/, view
@@ -96,38 +96,38 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
       assert_match /#{Regexp.escape('success: (blog_post) =>')}/, view
       assert_match /#{Regexp.escape('@model = blog_post')}/, view
     end
-    
+
     assert_file "#{backbone_path}/views/blog_posts/edit_view.js.coffee" do |view|
       assert_match /class Dummy.Views.BlogPosts.EditView extends Backbone.View/, view
       assert_match /#{Regexp.escape('JST["backbone/templates/blog_posts/edit"]')}/, view
       assert_match /#{Regexp.escape('"submit #edit-blog_post" : "update"')}/, view
       assert_match /#{Regexp.escape('success : (blog_post) =>')}/, view
     end
-    
+
     assert_file "#{backbone_path}/views/blog_posts/blog_post_view.js.coffee" do |view|
       assert_match /class Dummy.Views.BlogPosts.BlogPostView extends Backbone.View/, view
       assert_match /#{Regexp.escape('@template(@model.toJSON() )')}/, view
       assert_match /#{Regexp.escape('JST["backbone/templates/blog_posts/blog_post"]')}/, view
     end
   end
-  
+
   test "generate template files" do
     run_generator
-     
+
     assert_file "#{backbone_path}/templates/posts/index.jst.ejs"
-    
+
     assert_file "#{backbone_path}/templates/posts/new.jst.ejs" do |view|
       assert_match /#{Regexp.escape('<form id="new-post" name="post">')}/, view
     end
-    
+
     assert_file "#{backbone_path}/templates/posts/edit.jst.ejs" do |view|
       assert_match /#{Regexp.escape('<form id="edit-post" name="post">')}/, view
     end
-    
+
     assert_file "#{backbone_path}/templates/posts/show.jst.ejs"
     assert_file "#{backbone_path}/templates/posts/post.jst.ejs"
   end
-   
+
   test "generate template files for model with two words" do
     run_generator %w(BlogPost title:string content:string)
 
@@ -144,29 +144,29 @@ class ScaffoldGeneratorTest < Rails::Generators::TestCase
     assert_file "#{backbone_path}/templates/blog_posts/show.jst.ejs"
     assert_file "#{backbone_path}/templates/blog_posts/blog_post.jst.ejs"
   end
-   
+
   test "backbone model generator is invoked" do
     run_generator
-    
+
     assert_file "#{backbone_path}/models/post.js.coffee" do |model|
       assert_match /url: '\/posts'/, model
       assert_match /paramRoot: 'post'/, model
-      
+
       assert_match /title: null/, model
       assert_match /content: null/, model
     end
   end
-  
+
   test "backbone model generator is invoked for model with two words" do
     run_generator %w(BlogPost title:string content:string)
-    
+
     assert_file "#{backbone_path}/models/blog_post.js.coffee" do |model|
       assert_match /url: '\/blog_posts'/, model
       assert_match /paramRoot: 'blog_post'/, model
-      
+
       assert_match /title: null/, model
       assert_match /content: null/, model
     end
   end
-  
+
 end

--- a/vendor/assets/javascripts/backbone_rails_sync.js
+++ b/vendor/assets/javascripts/backbone_rails_sync.js
@@ -5,12 +5,12 @@
     'delete': 'DELETE',
     'read'  : 'GET'
   };
-  
+
   var getUrl = function(object) {
     if (!(object && object.url)) return null;
     return _.isFunction(object.url) ? object.url() : object.url;
   };
-  
+
   var urlError = function() {
     throw new Error("A 'url' property or function must be specified");
   };
@@ -60,9 +60,9 @@
       model.trigger('sync:end');
       if (complete) complete(jqXHR, textStatus);
     };
-    
+
     // Make the request.
     return $.ajax(params);
   }
-  
+
 }).call(this);


### PR DESCRIPTION
Trailing whitespace is especially annoying in the generated files.

```
find -name .git -prune -o -type f -print | xargs perl -pi -e 's/\s+\n/\n/'
```

(The tests still pass.)
