### PR TITLE
Only depend on railties

### DIFF
--- a/backbone-rails.gemspec
+++ b/backbone-rails.gemspec
@@ -6,14 +6,14 @@ Gem::Specification.new do |s|
   s.authors     = ["Ryan Fitzgerald", "Code Brew Studios"]
   s.email       = ["ryan@codebrewstudios.com"]
   s.homepage    = "http://github.com/codebrew/backbone-rails"
-  
+
   s.summary = "Use backbone.js with rails 3.1"
   s.description = "Quickly setup backbone.js for use with rails 3.1. Generators are provided to quickly get started."
   s.files = Dir["lib/**/*"] + Dir["vendor/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
-  
-  s.add_dependency('rails', '~> 3.1.0')
+
+  s.add_dependency('railties', '~> 3.1.0')
   s.add_dependency('coffee-script', '~> 2.2.0')
   s.add_dependency('ejs', '~> 1.0.0')
-  
+
   s.require_paths = ['lib']
 end


### PR DESCRIPTION
Hi,

I'm building a database-less site but I wanted to take advantage of rails 3.1 asset pipeline. Since rails-backbone depends on "rails", it was automatically requiring "activerecord" - and thus shooting a "connection not stablished error".

Depending only on railties fixes this.
