### PR TITLE
Rails 3.2

### DIFF
--- a/backbone-rails.gemspec
+++ b/backbone-rails.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.description = "Quickly setup backbone.js for use with rails 3.1. Generators are provided to quickly get started."
   s.files = Dir["lib/**/*"] + Dir["vendor/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
   
-  s.add_dependency('railties', '~> 3.1.0')
+  s.add_dependency('railties', '>= 3.1.0')
   s.add_dependency('coffee-script', '~> 2.2.0')
   s.add_dependency('ejs', '~> 1.0.0')
   


### PR DESCRIPTION
I tested this gem for about a week with rails 3.2 rc without problems (asset pipeline and generators).

Is there a reason for the hard dependency on 3.1 I don't know?

Cheers,
Marc
