### PR TITLE
Fixed README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Edit your posts index view `app/views/posts/index.html.erb` with the following c
     
 If you prefer haml, this is equivalent to inserting the following code into `app/views/posts/index.html.haml`:
 
+    #posts
     :javascript
       $(function() {
         // Blog is the app name


### PR DESCRIPTION
The example in HAML part of the README.md did not contain the #posts div. I fixed it. 

For details about the ugly diff, please note that this seems to be a bug in git.  Details in the diff comment: https://github.com/iblue/backbone-rails/commit/500d5645be2e3c64030ca3bd570a5ec0c651758f
