### PR TITLE
Zepto support

### DIFF
--- a/vendor/assets/javascripts/backbone_zepto_datalink.js.coffee
+++ b/vendor/assets/javascripts/backbone_zepto_datalink.js.coffee
@@ -1,0 +1,14 @@
+extensions =
+  backboneLink: (model) ->
+    $(this).find('input,select,textarea').each ->
+      el = $(this)
+      name = el.attr 'name'
+      model.bind "change:#{name}", ->
+        el.val(model.get('name'))
+      el.on 'change', ->
+        attrs = {}
+        attrs[el.attr('name')] = el.val()
+        model.set attrs
+
+
+$.extend $.fn, extensions


### PR DESCRIPTION
The datalink script depends on jQuery global and uses the proprietary jQuery selector `:script`, neither of which are compatible with Zepto.

This PR overcomes these issues by introducing an alternative script that's compatible with Zepto.
