### PR TITLE
scaffold generated routes prepended with / cause issues

### DIFF
--- a/lib/generators/backbone/scaffold/templates/router.coffee
+++ b/lib/generators/backbone/scaffold/templates/router.coffee
@@ -4,10 +4,10 @@ class <%= router_namespace %>Router extends Backbone.Router
     @<%= plural_model_name %>.reset options.<%= plural_model_name %>
 
   routes:
-    "/new"      : "new<%= class_name %>"
-    "/index"    : "index"
-    "/:id/edit" : "edit"
-    "/:id"      : "show"
+    "new"      : "new<%= class_name %>"
+    "index"    : "index"
+    ":id/edit" : "edit"
+    ":id"      : "show"
     ".*"        : "index"
 
   new<%= class_name %>: ->


### PR DESCRIPTION
Similar to: https://github.com/codebrew/backbone-rails/commit/3a8b3f02bd705fe47a292db8faa3ca0fb1f34356

This pull removes the / for the scaffold generator.
