### PR TITLE
README.md missing div in haml example

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Edit your posts index view `app/views/posts/index.html.erb` with the following c
     
 If you prefer haml, this is equivalent to inserting the following code into `app/views/posts/index.html.haml`:
 
+    #posts
+
     :javascript
       $(function() {
         // Blog is the app name


### PR DESCRIPTION
Hello. The haml example in the readme is missing the #posts div.

Thanks for the great gem!
- Andy
