### PR TITLE
Allows the X-CSRF-Token to be skipped optionally

### DIFF
--- a/vendor/assets/javascripts/backbone_rails_sync.js
+++ b/vendor/assets/javascripts/backbone_rails_sync.js
@@ -23,9 +23,10 @@
       type:         type,
       dataType:     'json',
       beforeSend: function( xhr ) {
-        var token = $('meta[name="csrf-token"]').attr('content');
-        if (token) xhr.setRequestHeader('X-CSRF-Token', token);
-
+        if (!options.noCSRF) {
+          var token = $('meta[name="csrf-token"]').attr('content');
+          if (token) xhr.setRequestHeader('X-CSRF-Token', token);  
+        }
         model.trigger('sync:start');
       }
     }, options);


### PR DESCRIPTION
This is necessary for doing any sort of cross-domain request when using backbone-rails.
