### PR TITLE
Readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Edit your posts index view `app/views/posts/index.html.erb` with the following c
     
 If you prefer haml, this is equivalent to inserting the following code into `app/views/posts/index.html.haml`:
 
+    %div#posts
+    
     :javascript
       $(function() {
         // Blog is the app name


### PR DESCRIPTION
Adds a haml equivalent of div id="posts" line to example usage, possibly saving someone 2 hours of figuring out why the page is blank.
