### PR TITLE
Add blank #posts div in haml example

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ Edit your posts index view `app/views/posts/index.html.erb` with the following c
     </script>
     
 If you prefer haml, this is equivalent to inserting the following code into `app/views/posts/index.html.haml`:
-
+    
+    #posts    
     :javascript
       $(function() {
         // Blog is the app name


### PR DESCRIPTION
Followed the setup directions (They we're great!), but ran into one minor issue. The haml example needs a blank posts div to insert elements into
