### PR TITLE
fix install generator to play nice with CoffeeScript application manifests

### DIFF
--- a/lib/generators/backbone/install/install_generator.rb
+++ b/lib/generators/backbone/install/install_generator.rb
@@ -13,9 +13,20 @@ module Backbone
                               :desc => "Skip Git ignores and keeps"
                                       
       def inject_backbone
-        inject_into_file "app/assets/javascripts/application.js", :before => "//= require_tree" do
-          "//= require underscore\n//= require backbone\n//= require backbone_rails_sync\n//= require backbone_datalink\n//= require backbone/#{application_name.underscore}\n"
-        end
+        # for JavaScript application.js manifest:        
+        if File.exists? "#{Rails.root}/app/assets/javascripts/application.js"
+          
+          inject_into_file "app/assets/javascripts/application.js", :after => "//= require jquery_ujs" do
+            "\n//= require underscore\n//= require backbone\n//= require backbone_rails_sync\n//= require backbone_datalink\n//= require backbone/#{application_name.underscore}\n"
+          end  
+        
+        # ...or for CoffeeScript application.js.coffee manifest:
+        elsif File.exists? "#{Rails.root}/app/assets/javascripts/application.js.coffee"
+          
+          inject_into_file "app/assets/javascripts/application.js.coffee", :after => "#= require jquery_ujs" do
+            "\n#= require underscore\n#= require backbone\n#= require backbone_rails_sync\n#= require backbone_datalink\n#= require backbone/#{application_name.underscore}\n"
+          end  
+        end        
       end
     
       def create_dir_layout


### PR DESCRIPTION
The install generator choked for me with a stack trace because I have an application.js.coffee manifest instead of application.js.  Also, I modified the generator to inject the require directives after "require jquery_ujs" (instead of "require_tree") because often times (as in my own present case) I'm require_tree'ing several directories and so the generator was injecting the require directives for backbone (and the dependencies) several times over (before each "require_tree").  It's a safe assumption that just about every rails app will have a "require jquery_ujs" line in the application js/coffee manifest, I think, but if you disagree you can ignore/revert that.
