### PR TITLE
Upgrade for Backbone 0.9.10

### DIFF
--- a/vendor/assets/javascripts/backbone_rails_sync.js
+++ b/vendor/assets/javascripts/backbone_rails_sync.js
@@ -62,6 +62,18 @@
       if (complete) complete(jqXHR, textStatus);
     };
     
+    var success = options.success;
+    params.success = function(resp) {
+      if (success) success(model, resp, options);
+      model.trigger('sync', model, resp, options);
+    };
+
+    var error = options.error;
+    params.error = function(xhr) {
+      if (error) error(model, xhr, options);
+      model.trigger('error', model, xhr, options);
+    };
+    
     // Make the request.
     return $.ajax(params);
   }


### PR DESCRIPTION
Stops error "Object has no method 'reset'" due to new fetch methods in latest backbone.
