### PR TITLE
Boolean attributes now sync properly for radio buttons and checkboxes.

### DIFF
--- a/vendor/assets/javascripts/backbone_datalink.js
+++ b/vendor/assets/javascripts/backbone_datalink.js
@@ -1,4 +1,7 @@
 (function($) {
+  $.fn.isCheckable = function() {
+    return ["checkbox", "radio"].indexOf(this.attr("type")) >= 0;
+  };
   return $.extend($.fn, {
     backboneLink: function(model) {
       return $(this).find(":input").each(function() {
@@ -6,13 +9,21 @@
         el = $(this);
         name = el.attr("name");
         model.bind("change:" + name, function() {
-          return el.val(model.get(name));
+          if (el.isCheckable()) {
+            return el.prop("checked", model.get(name));
+          } else {
+            return el.val(model.get(name));
+          }
         });
         return $(this).bind("change", function() {
           var attrs;
           el = $(this);
           attrs = {};
-          attrs[el.attr("name")] = el.val();
+          if (el.isCheckable()) {
+            attrs[el.attr("name")] = el.is(":checked");
+          } else {
+            attrs[el.attr("name")] = el.val();
+          }
           return model.set(attrs);
         });
       });


### PR DESCRIPTION
Checkable inputs need the property "checked" to be settled to
true/false instead of the "value" attribute.
