### PR TITLE
README.md: fixed inconsistency with haml example

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Edit your posts index view `app/views/posts/index.html.erb` with the following c
     
 If you prefer haml, this is equivalent to inserting the following code into `app/views/posts/index.html.haml`:
 
+    #posts
+    
     :javascript
       $(function() {
         // Blog is the app name


### PR DESCRIPTION
I just fixed an inconsistency I noticed with the haml example not including the div tag. I'm not sure if you left it out intentionally, but thought I'd correct in case you hadn't.

Thanks for the great gem!

Cheers,
Andy
