### PR TITLE
Fix PATCH support in sync function

### DIFF
--- a/vendor/assets/javascripts/backbone_rails_sync.js
+++ b/vendor/assets/javascripts/backbone_rails_sync.js
@@ -16,12 +16,13 @@
     // Serialize data, optionally using paramRoot
     if (options.data == null && model && (method === 'create' || method === 'update' || method === 'patch')) {
       options.contentType = 'application/json';
-      data = JSON.stringify(options.attrs || model.toJSON(options));
+      var attributes = options.attrs || model.toJSON(options);
+      var data;
       if (model.paramRoot) {
         data = {};
-        data[model.paramRoot] = model.toJSON(options);
+        data[model.paramRoot] = attributes;
       } else {
-        data = model.toJSON();
+        data = attributes;
       }
       options.data = JSON.stringify(data);
     }


### PR DESCRIPTION
As per the backbone documentation for model.save(http://backbonejs.org/#Model-save)

> If instead, you'd only like the changed attributes to be sent to the server, call model.save(attrs, {patch: true}). You'll get an HTTP PATCH request to the server with just the passed-in attributes.

This currently doesn't work when including backbone_rails_sync, as the data option was always being set to model.toJSON, which returns all the model's attributes, when in fact it should be set to options.attrs if it's present, which contains only the attributes that have been changed when using the patch option.
