### PR TITLE
Add license to gemspec

### DIFF
--- a/backbone-rails.gemspec
+++ b/backbone-rails.gemspec
@@ -6,6 +6,7 @@ Gem::Specification.new do |s|
   s.authors     = ["Ryan Fitzgerald", "Code Brew Studios", "Manu S Ajith"]
   s.email       = ["ryan@codebrewstudios.com", "neo@codingarena.in"]
   s.homepage    = "http://github.com/codebrew/backbone-rails"
+  s.license     = "MIT"
   
   s.summary = "Use backbone.js with rails 3.1 and above apps"
   s.description = "Quickly setup backbone.js for use with rails 3.1 and above apps. Generators are provided to quickly get started."


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.